### PR TITLE
Update create new key link to use the direct one

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -312,7 +312,7 @@ export default function Home() {
                 Please enter your
                 <a
                   className="mx-2 underline hover:opacity-50"
-                  href="https://openai.com/product"
+                  href="https://platform.openai.com/account/api-keys"
                 >
                   OpenAI API key
                 </a>


### PR DESCRIPTION
Updated link to use the one that directly allow to create a new key, if user not logged in, OpenAI will redirect theirself.